### PR TITLE
add pagination to `GET /rides` endpoint

### DIFF
--- a/src/helpers/NumberHelper.js
+++ b/src/helpers/NumberHelper.js
@@ -1,0 +1,5 @@
+module.exports = {
+    numberize: (str, defaultNumber) => {
+        return Number(str) ? Number(str) : defaultNumber
+    }
+}

--- a/src/helpers/__tests__/NumberHelper.test.js
+++ b/src/helpers/__tests__/NumberHelper.test.js
@@ -1,0 +1,24 @@
+const assert = require('assert')
+const {numberize} = require('../NumberHelper')
+
+describe('/helpers/NumberHelper', () => {
+    it('should return the input0', () => {
+        assert(numberize(10, 1), 10)
+    })
+
+    it('should return default value if number is 0', () => {
+        assert(numberize(0, 1), 1)
+    })
+
+    it('should return default value if input is string', () => {
+        assert(numberize('I am a string', 1), 1)
+    })
+
+    it('should return default value if input is null', () => {
+        assert(numberize(null, 1), 1)
+    })
+
+    it('should return default value if input is undefined', () => {
+        assert(numberize(undefined, 1), 1)
+    })
+})

--- a/src/routes/rides.js
+++ b/src/routes/rides.js
@@ -1,10 +1,10 @@
 const router = require('express').Router()
 const uuidV4 = require('uuid/v4')
 
-const db = require('../singletons/database')()
 const DatabaseHelper = require('../helpers/DatabaseHelper')
 const logger = require('../singletons/logger')()
 const ridesValidator = require('../validators/ridesValidator')
+const { numberize } = require('../helpers/NumberHelper')
 
 router.post('/', async (req, res) => {
   const startLatitude = Number(req.body.start_lat)
@@ -65,7 +65,13 @@ router.post('/', async (req, res) => {
 
 router.get('/', async (req, res) => {
   try {
-    const rows = await DatabaseHelper.all('SELECT * FROM Rides')
+    const page = numberize(req.query.page, 1)
+    const size = numberize(req.query.size, 10)
+
+    const rows = await DatabaseHelper.all('SELECT * FROM Rides LIMIT ?, ?', [
+      (page - 1) * size,
+      size
+    ])
     if (rows.length === 0) {
       return res.status(410).send({
         error_code: 'RIDES_NOT_FOUND_ERROR',


### PR DESCRIPTION
# Goal
Add pagination to `GET /rides` endpoint

# Additional Work
Create `numberize` function inside `NumberHelper`, to help check the input is number. If not number or 0, then return default value.